### PR TITLE
Fail on text-valued PKs; change test env var

### DIFF
--- a/lib/pgslice/cli/fill.rb
+++ b/lib/pgslice/cli/fill.rb
@@ -1,4 +1,8 @@
 module PgSlice
+
+  PG_NUMERIC_TYPES = ["smallint", "integer", "bigint", "decimal", "numeric",
+                      "real", "double precision", "smallserial", "bigserial"]
+
   class CLI
     desc "fill TABLE", "Fill the partitions in batches"
     option :batch_size, type: :numeric, default: 10000, desc: "Batch size"
@@ -41,12 +45,11 @@ module PgSlice
       primary_key = schema_table.primary_key[0]
       abort "No primary key" unless primary_key
 
-      max_source_id = nil
-      begin
-        max_source_id = source_table.max_id(primary_key)
-      rescue PG::UndefinedFunction
+      if !PG_NUMERIC_TYPES.include? source_table.column_type(primary_key)
         abort "Only numeric primary keys are supported"
       end
+
+      max_source_id = source_table.max_id(primary_key)
 
       max_dest_id =
         if options[:start]

--- a/lib/pgslice/table.rb
+++ b/lib/pgslice/table.rb
@@ -82,8 +82,13 @@ module PgSlice
     end
 
     def column_cast(column)
-      data_type = execute("SELECT data_type FROM information_schema.columns WHERE table_schema = $1 AND table_name = $2 AND column_name = $3", [schema, name, column])[0]["data_type"]
+      data_type = column_type(column)
       data_type == "timestamp with time zone" ? "timestamptz" : "date"
+    end
+
+    def column_type(column)
+      execute("SELECT data_type FROM information_schema.columns WHERE table_schema = $1 AND table_name = $2 AND column_name = $3",
+              [schema, name, column])[0]["data_type"]
     end
 
     def max_id(primary_key, below: nil, where: nil)

--- a/test/pgslice_test.rb
+++ b/test/pgslice_test.rb
@@ -30,6 +30,19 @@ class PgSliceTest < Minitest::Test
     assert true
   end
 
+  def test_invalid_pks
+    ["Invalid_UUID_PK", "Invalid_TEXT_PK"].each do |t|
+      run_command "prep #{t} createdAt month"
+      run_command "add_partitions #{t} --intermediate --past 1 --future 1"
+      _, err = capture_io do
+        assert_raises SystemExit do
+          run_command "fill #{t}"
+        end
+      end
+      assert_match /Only numeric primary keys are supported/, err
+    end
+  end
+
   def test_trigger_based
     assert_period "month", trigger_based: true
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,6 +11,10 @@ DROP TABLE IF EXISTS "Posts_intermediate" CASCADE;
 DROP TABLE IF EXISTS "Posts" CASCADE;
 DROP TABLE IF EXISTS "Posts_retired" CASCADE;
 DROP FUNCTION IF EXISTS "Posts_insert_trigger"();
+DROP TABLE IF EXISTS "Invalid_UUID_PK" CASCADE;
+DROP TABLE IF EXISTS "Invalid_TEXT_PK" CASCADE;
+DROP TABLE IF EXISTS "Invalid_UUID_PK_intermediate" CASCADE;
+DROP TABLE IF EXISTS "Invalid_TEXT_PK_intermediate" CASCADE;
 DROP TABLE IF EXISTS "Users" CASCADE;
 CREATE TABLE "Users" (
   "Id" SERIAL PRIMARY KEY
@@ -25,4 +29,15 @@ CREATE TABLE "Posts" (
 );
 CREATE INDEX ON "Posts" ("createdAt");
 INSERT INTO "Posts" ("createdAt", "createdAtTz", "createdOn") SELECT NOW(), NOW(), NOW() FROM generate_series(1, 10000) n;
+
+CREATE TABLE "Invalid_UUID_PK" (
+  "Id" UUID PRIMARY KEY,
+  "createdAt" timestamp
+);
+
+CREATE TABLE "Invalid_TEXT_PK" (
+  "Id" TEXT PRIMARY KEY,
+  "createdAt" timestamp
+);
+
 SQL


### PR DESCRIPTION
Update non-numeric PK handling to fail on text as well as UUID.