### PR TITLE
Return NEW to unblock any triggers running after this trigger

### DIFF
--- a/lib/pgslice/cli/add_partitions.rb
+++ b/lib/pgslice/cli/add_partitions.rb
@@ -117,7 +117,7 @@ CREATE OR REPLACE FUNCTION #{quote_ident(trigger_name)}()
         ELSE
             RAISE EXCEPTION 'Date out of range. Ensure partitions are created.';
         END IF;
-        RETURN NULL;
+        RETURN NEW;
     END;
     $$ LANGUAGE plpgsql;
           SQL


### PR DESCRIPTION
### Problem
`RETURN NULL` in a trigger stops all subsequent triggers.

From Postgres docs:


> If more than one trigger is defined for the same event on the same relation, the triggers will be fired in alphabetical order by trigger name. In the case of BEFORE and INSTEAD OF triggers, the possibly-modified row returned by each trigger becomes the input to the next trigger. If any BEFORE or INSTEAD OF trigger returns NULL, the operation is abandoned for that row and subsequent triggers are not fired (for that row).

Source: https://www.postgresql.org/docs/10/trigger-definition.html?origin_team=T0258G2C6

### Solution
`RETURN NEW` instead.