### PR TITLE
Fix: uninitialized constant PgSlice::Table::SQL_FORMAT

### DIFF
--- a/lib/pgslice/table.rb
+++ b/lib/pgslice/table.rb
@@ -144,7 +144,7 @@ module PgSlice
         function_def = execute("SELECT pg_get_functiondef(oid) FROM pg_proc WHERE proname = $1", [trigger_name])[0]
         return [] unless function_def
         function_def = function_def["pg_get_functiondef"]
-        sql_format = SQL_FORMAT.find { |_, f| function_def.include?("'#{f}'") }
+        sql_format = Helpers::SQL_FORMAT.find { |_, f| function_def.include?("'#{f}'") }
         return [] unless sql_format
         period = sql_format[0]
         field = /to_char\(NEW\.(\w+),/.match(function_def)[1]


### PR DESCRIPTION
Version: 
```
levkokotov@Lev-C02X347FJGH5:~$ pgslice --version
pgslice 0.4.5
```

Got this error locally:

```
levkokotov@Lev-C02X347FJGH5:~$ pgslice add_partitions state_changes
Traceback (most recent call last):
	8: from /Users/levkokotov/.rbenv/versions/2.6.3/bin/pgslice:23:in `<main>'
	7: from /Users/levkokotov/.rbenv/versions/2.6.3/bin/pgslice:23:in `load'
	6: from /Users/levkokotov/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/pgslice-0.4.5/exe/pgslice:5:in `<top (required)>'
	5: from /Users/levkokotov/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/thor-0.20.3/lib/thor/base.rb:466:in `start'
	4: from /Users/levkokotov/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/thor-0.20.3/lib/thor.rb:387:in `dispatch'
	3: from /Users/levkokotov/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/thor-0.20.3/lib/thor/invocation.rb:126:in `invoke_command'
	2: from /Users/levkokotov/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/thor-0.20.3/lib/thor/command.rb:27:in `run'
	1: from /Users/levkokotov/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/pgslice-0.4.5/lib/pgslice/cli/add_partitions.rb:18:in `add_partitions'
/Users/levkokotov/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/pgslice-0.4.5/lib/pgslice/table.rb:147:in `fetch_settings': uninitialized constant PgSlice::Table::SQL_FORMAT (NameError)
```

Fixed by adding specificity to the constant namespace.