### PR TITLE
Ensure `Table#partitions` is sorted before using them

### DIFF
--- a/lib/pgslice/table.rb
+++ b/lib/pgslice/table.rb
@@ -117,6 +117,7 @@ module PgSlice
         WHERE
           nmsp_parent.nspname = $1 AND
           parent.relname = $2
+        ORDER BY name ASC
       SQL
       execute(query, [schema, name]).map { |r| Table.new(r["schema"], r["name"]) }
     end


### PR DESCRIPTION
I had an issue where the `fill` command turned out to not insert anything as it was relying on the order of `Table#partitions` to be sorted with the oldest partition first, and newest partition last. Mine was returning partitions with the newest first, oldest last, which generated fill statements with out of order dates (`starting_time` was the newest partition, and `ending_time` was the oldest partition).

Example:

```sql
... WHERE "id" > X AND "id" <= Y AND "time" >= '2020-06-01'::date AND "time" < '2020-03-31'::date;
```

This change does rely on the partitions being lexicographical sortable for the purposes of date though.

I was on Postgres 11.2, and the partitions were created with `pgslice prepare ahoy_events time day` and `pgslice add_partitions ahoy_events --intermediate --past 60 --future 3`