### PR TITLE
Skip primary key creation for child tables if they have been created

### DIFF
--- a/lib/pgslice/cli/add_partitions.rb
+++ b/lib/pgslice/cli/add_partitions.rb
@@ -71,7 +71,7 @@ CREATE TABLE #{quote_table(partition)}
           SQL
         end
 
-        queries << "ALTER TABLE #{quote_table(partition)} ADD PRIMARY KEY (#{primary_key.map { |k| quote_ident(k) }.join(", ")});" if primary_key.any?
+        queries << "ALTER TABLE #{quote_table(partition)} ADD PRIMARY KEY (#{primary_key.map { |k| quote_ident(k) }.join(", ")});" if primary_key.any? && !partition.primary_key.any?
 
         index_defs.each do |index_def|
           queries << make_index_def(index_def, partition)

--- a/test/pgslice_test.rb
+++ b/test/pgslice_test.rb
@@ -42,7 +42,9 @@ class PgSliceTest < Minitest::Test
   end
 
   def test_day_with_primary_key
-    assert_period( "day", add_pk_to_parent: true )
+    if server_version_num >= 110000
+      assert_period( "day", add_pk_to_parent: true )
+    end
   end
 
   private

--- a/test/pgslice_test.rb
+++ b/test/pgslice_test.rb
@@ -75,7 +75,7 @@ class PgSliceTest < Minitest::Test
 
     declarative = server_version_num >= 100000 && !trigger_based
 
-    if declarative
+    if declarative && !add_pk_to_parent
       refute_primary_key "Posts_intermediate"
     else
       assert_primary_key "Posts_intermediate"
@@ -214,7 +214,7 @@ class PgSliceTest < Minitest::Test
 
   def assert_primary_key(table_name)
     result = primary_key(table_name)
-    assert_match "PRIMARY KEY (\"Id\")", result["def"]
+    assert_match /PRIMARY\ KEY\ \("Id/, result["def"]
   end
 
   def refute_primary_key(table_name)


### PR DESCRIPTION
Hi @ankane ,

In postgres 11+, if a partition is created for a table with a primary key, a primary key on the child table may be created automatically.  This causes `pgslice add_partitions` to fail when it tries to add a primary key to the child table.

```
# create table foo (id serial, dt timestamptz) partition by range(dt);
CREATE TABLE

# alter table foo add primary key (id,dt);
ALTER TABLE

# create table foo_partition partition of foo for values from ('2020-01-01 UTC') to ('2020-10-01 UTC');
CREATE TABLE

# \d foo_partition
                                Table "public.foo_partition"
 Column |           Type           | Collation | Nullable |             Default
--------+--------------------------+-----------+----------+---------------------------------
 id     | integer                  |           | not null | nextval('foo_id_seq'::regclass)
 dt     | timestamp with time zone |           | not null |
Partition of: foo FOR VALUES FROM ('2019-12-31 19:00:00-05') TO ('2020-09-30 20:00:00-04')
Indexes:
    "foo_partition_pkey" PRIMARY KEY, btree (id, dt)

```

This is a little PR to skip adding the primary key if it has been added already.

thanks
Brian
cc: @sherin

