### PR TITLE
Fix add_partition script to skip adding primary key in version3+

### DIFF
--- a/lib/pgslice/cli/add_partitions.rb
+++ b/lib/pgslice/cli/add_partitions.rb
@@ -46,12 +46,13 @@ module PgSlice
       if version < 3
         index_defs = schema_table.index_defs
         fk_defs = schema_table.foreign_keys
+        primary_key = schema_table.primary_key
       else
         index_defs = []
         fk_defs = []
+        primary_key = []
       end
 
-      primary_key = schema_table.primary_key
       tablespace_str = tablespace.empty? ? "" : " TABLESPACE #{quote_ident(tablespace)}"
 
       added_partitions = []


### PR DESCRIPTION
Starting PG11, indexes and primary key constraint are propagated to the child tables, so trying to  ADD PRIMARY KEY on child tables will cause `PG::InvalidTableDefinition: ERROR:  multiple primary keys for table are not allowed` error