### PR TITLE
Include compression when creating intermediate table

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ pgslice prep visits created_at month
 ```sql
 BEGIN;
 
-CREATE TABLE "public"."visits_intermediate" (LIKE "public"."visits" INCLUDING DEFAULTS INCLUDING CONSTRAINTS INCLUDING STORAGE INCLUDING COMMENTS INCLUDING COMPRESSION) PARTITION BY RANGE ("created_at");
+CREATE TABLE "public"."visits_intermediate" (LIKE "public"."visits" INCLUDING DEFAULTS INCLUDING CONSTRAINTS INCLUDING STORAGE INCLUDING COMMENTS) PARTITION BY RANGE ("created_at");
 
 CREATE INDEX ON "public"."visits_intermediate" USING btree ("created_at");
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ pgslice prep visits created_at month
 ```sql
 BEGIN;
 
-CREATE TABLE "public"."visits_intermediate" (LIKE "public"."visits" INCLUDING DEFAULTS INCLUDING CONSTRAINTS INCLUDING STORAGE INCLUDING COMMENTS) PARTITION BY RANGE ("created_at");
+CREATE TABLE "public"."visits_intermediate" (LIKE "public"."visits" INCLUDING DEFAULTS INCLUDING CONSTRAINTS INCLUDING STORAGE INCLUDING COMMENTS INCLUDING COMPRESSION) PARTITION BY RANGE ("created_at");
 
 CREATE INDEX ON "public"."visits_intermediate" USING btree ("created_at");
 

--- a/lib/pgslice/cli/prep.rb
+++ b/lib/pgslice/cli/prep.rb
@@ -39,8 +39,14 @@ module PgSlice
       declarative = version > 1
 
       if declarative && options[:partition]
+        version_specific_including =
+          if server_version_num >= 130000
+            " INCLUDING COMPRESSION"
+          else
+            ""
+          end
         queries << <<-SQL
-CREATE TABLE #{quote_table(intermediate_table)} (LIKE #{quote_table(table)} INCLUDING DEFAULTS INCLUDING CONSTRAINTS INCLUDING STORAGE INCLUDING COMMENTS INCLUDING COMPRESSION) PARTITION BY RANGE (#{quote_ident(column)});
+CREATE TABLE #{quote_table(intermediate_table)} (LIKE #{quote_table(table)} INCLUDING DEFAULTS INCLUDING CONSTRAINTS INCLUDING STORAGE INCLUDING COMMENTS#{version_specific_including}) PARTITION BY RANGE (#{quote_ident(column)});
         SQL
 
         if version == 3

--- a/lib/pgslice/cli/prep.rb
+++ b/lib/pgslice/cli/prep.rb
@@ -40,7 +40,7 @@ module PgSlice
 
       if declarative && options[:partition]
         queries << <<-SQL
-CREATE TABLE #{quote_table(intermediate_table)} (LIKE #{quote_table(table)} INCLUDING DEFAULTS INCLUDING CONSTRAINTS INCLUDING STORAGE INCLUDING COMMENTS) PARTITION BY RANGE (#{quote_ident(column)});
+CREATE TABLE #{quote_table(intermediate_table)} (LIKE #{quote_table(table)} INCLUDING DEFAULTS INCLUDING CONSTRAINTS INCLUDING STORAGE INCLUDING COMMENTS INCLUDING COMPRESSION) PARTITION BY RANGE (#{quote_ident(column)});
         SQL
 
         if version == 3


### PR DESCRIPTION
This pull request adds the INCLUDING COMPRESSION clause to the partitioned table creation process for both the README example and the lib/pgslice/cli/prep.rb file. This change ensures that compression settings are preserved when creating a new partitioned table from an existing table, providing more efficient storage and performance.